### PR TITLE
docs(readme): correct app settings config file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,14 @@ Tracked repositories are stored in `.gh-pr-lander.repos.json`:
 
 ### App Settings
 
-Create `~/.gh-pr-lander.toml` (or `.gh-pr-lander.toml` in the current directory):
+Create `config.toml` inside the app's config directory:
+
+| OS            | Path                                                        |
+|---------------|-------------------------------------------------------------|
+| Linux / macOS | `$XDG_CONFIG_HOME/gh-pr-lander/config.toml` (defaults to `~/.config/gh-pr-lander/config.toml`) |
+| Windows       | `%APPDATA%\gh-pr-lander\config.toml`                        |
+
+To use a different file ad-hoc, pass `--config <path>` on the command line.
 
 ```toml
 # IDE to open PRs in (default: "code")

--- a/crates/gh-pr-lander/src/keybindings.rs
+++ b/crates/gh-pr-lander/src/keybindings.rs
@@ -296,7 +296,7 @@ impl Keymap {
         self.compact_hint_for_command_filtered(command, |_| true)
     }
 
-    /// Like [`compact_hint_for_command`], but only keeps hints for which `keep`
+    /// Like [`Self::compact_hint_for_command`], but only keeps hints for which `keep`
     /// returns true. Useful when a view captures certain key shapes (e.g. a
     /// text input swallows single ASCII chars) and the footer should hide them.
     /// Returns `None` if no hints match the command, or if the filter rejects


### PR DESCRIPTION
## Summary
- README told users to drop `~/.gh-pr-lander.toml` (or a CWD-local `.gh-pr-lander.toml`), but the loader only reads `<config_dir>/gh-pr-lander/config.toml` — files at the documented paths were silently ignored.
- Documents the actual per-OS location (`~/.config/gh-pr-lander/config.toml` on macOS/Linux, `%APPDATA%\gh-pr-lander\config.toml` on Windows) and the existing `--config <path>` override flag.

Closes #36

## Test plan
- [x] `cat README.md` renders the new path table correctly
- [x] Drop a `config.toml` with a custom `approval_message` at `~/.config/gh-pr-lander/config.toml`, run the app, approve a PR, confirm the configured message is posted (instead of `:rocket: thanks for your contribution`)